### PR TITLE
Changes X11 res_name to "Godot_Engine"

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -344,7 +344,7 @@ void OS_X11::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 	/* set the name and class hints for the window manager to use */
 	classHint = XAllocClassHint();
 	if (classHint) {
-		classHint->res_name = (char *)"Godot";
+		classHint->res_name = (char *)"Godot_Engine";
 		classHint->res_class = (char *)"Godot";
 	}
 	XSetClassHint(x11_display, x11_window, classHint);


### PR DESCRIPTION
Add additional/alternative WM_CLASS; only affects the game window, avoids redundancy and allows finer control in WMs (fixes #5265)

I release this code under the same terms as specified in Godot's LICENSE.md file (MIT license).